### PR TITLE
Remove unused channel

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,6 @@ func (c *Client) Run(processor processor.Interface, filter filter.Interface, pre
 	projs := make(chan projects.Project)
 	read := make(chan resource.Resource)
 	filtered := make(chan resource.Resource)
-	fullInfo := make(chan resource.Resource)
 
 	// create done channel
 	done := make(chan bool)
@@ -39,8 +38,7 @@ func (c *Client) Run(processor processor.Interface, filter filter.Interface, pre
 
 	go processor.ListResources(projs, read, opts)
 	go filter.Filter(read, filtered)
-	go processor.RetrieveInfoResource(filtered, fullInfo)
-	go preparer.Prepare(fullInfo, done, &mapWg)
+	go preparer.Prepare(filtered, done, &mapWg)
 
 	<-done
 }

--- a/processor/interface.go
+++ b/processor/interface.go
@@ -10,5 +10,4 @@ import (
 type Interface interface {
 	ListProjects(chan projects.Project)
 	ListResources(chan projects.Project, chan resource.Resource, gophercloud.AuthOptions)
-	RetrieveInfoResource(chan resource.Resource, chan resource.Resource)
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -22,7 +22,6 @@ type Processor struct {
 type processorI interface {
 	Reader() *reader.Reader
 	Process(projects.Project, *gophercloud.ProviderClient, chan resource.Resource, *sync.WaitGroup)
-	RetrieveInfo(chan resource.Resource, *sync.WaitGroup, resource.Resource)
 }
 
 // CreateProcessor creates Processor to manage reading from OpenNebula.
@@ -77,22 +76,4 @@ func (p *Processor) ListResources(projChan chan projects.Project, read chan reso
 
 	wg.Wait()
 	close(read)
-}
-
-// RetrieveInfoResource range over filtered resource and calls method to retrieve resource info.
-func (p *Processor) RetrieveInfoResource(filtered, fullInfo chan resource.Resource) {
-	var wg sync.WaitGroup
-
-	for accountable := range filtered {
-		if accountable == nil {
-			log.WithFields(log.Fields{"error": "no accountable"}).Error("error retrieve resource info")
-			continue
-		}
-
-		wg.Add(1)
-		go p.proc.RetrieveInfo(fullInfo, &wg, accountable)
-	}
-
-	wg.Wait()
-	close(fullInfo)
 }

--- a/resource/network/processor.go
+++ b/resource/network/processor.go
@@ -80,10 +80,3 @@ func (p *Processor) Process(project projects.Project, osClient *gophercloud.Prov
 		FloatingIPs: floatings,
 	}
 }
-
-// RetrieveInfo about virtual machines specific for a given user.
-func (p *Processor) RetrieveInfo(fullInfo chan resource.Resource, wg *sync.WaitGroup, res resource.Resource) {
-	defer wg.Done()
-
-	fullInfo <- res
-}

--- a/resource/server/processor.go
+++ b/resource/server/processor.go
@@ -76,15 +76,3 @@ func (p *Processor) Process(project projects.Project, osClient *gophercloud.Prov
 		read <- &s[i]
 	}
 }
-
-// RetrieveInfo calls method to retrieve server info.
-func (p *Processor) RetrieveInfo(fullInfo chan resource.Resource, wg *sync.WaitGroup, vm resource.Resource) {
-	defer wg.Done()
-
-	if vm == nil {
-		log.WithFields(log.Fields{}).Debug("retrieve info no vm")
-		return
-	}
-
-	fullInfo <- vm
-}

--- a/resource/storage/processor.go
+++ b/resource/storage/processor.go
@@ -200,15 +200,3 @@ func (p *Processor) processVolumes(osClient *gophercloud.ProviderClient, read ch
 		read <- &rs[i]
 	}
 }
-
-// RetrieveInfo - only for ? relevant.
-func (p *Processor) RetrieveInfo(fullInfo chan resource.Resource, wg *sync.WaitGroup, image resource.Resource) {
-	defer wg.Done()
-
-	if image == nil {
-		log.WithFields(log.Fields{}).Debug("retrieve info no image")
-		return
-	}
-
-	fullInfo <- image
-}


### PR DESCRIPTION
Function `retrieveInfo` is not needed for goat-os. Openstack calls contain all necessary info for building records.